### PR TITLE
Sepa Felder zu Client hinzugefügt

### DIFF
--- a/src/main/java/de/siegmar/billomat4j/domain/client/Client.java
+++ b/src/main/java/de/siegmar/billomat4j/domain/client/Client.java
@@ -19,6 +19,7 @@
 package de.siegmar.billomat4j.domain.client;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -57,6 +58,8 @@ public class Client extends AbstractMeta {
     private String bankAccountNumber;
     private String bankSwift;
     private String bankIban;
+    private String sepaMandate;
+    private LocalDate sepaMandateDate;
     private TaxRule taxRule;
     private SettingsType discountRateType;
     private BigDecimal discountRate;
@@ -282,6 +285,14 @@ public class Client extends AbstractMeta {
     public void setBankIban(final String bankIban) {
         this.bankIban = bankIban;
     }
+
+    public String getSepaMandate() { return sepaMandate; }
+
+    public void setSepaMandate(final String sepaMandate) { this.sepaMandate = sepaMandate; }
+
+    public LocalDate getSepaMandateDate() { return sepaMandateDate; }
+
+    public void setSepaMandateDate(final LocalDate sepaMandateDate ) { this.sepaMandateDate = sepaMandateDate; }
 
     public TaxRule getTaxRule() {
         return taxRule;

--- a/src/test/java/de/siegmar/billomat4j/client/ClientServiceIT.java
+++ b/src/test/java/de/siegmar/billomat4j/client/ClientServiceIT.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -194,6 +195,17 @@ public class ClientServiceIT extends AbstractServiceIT {
         client.setArchived(true);
         clientService.updateClient(client);
         assertTrue(client.getArchived());
+    }
+
+    @Test
+    public void setSepaMandate() {
+        final String sepaMandateNr = "DRSTE3452TZERTS89ZUTZBVS67";
+        final LocalDate sepaDate = LocalDate.of(2018, 10, 10);
+        final Client client = buildClient("Sepa Company");
+        client.setSepaMandate(sepaMandateNr);
+        client.setSepaMandateDate(sepaDate);
+        clientService.createClient(client);
+        assertNotNull(client.getId());
     }
 
 }

--- a/src/test/java/de/siegmar/billomat4j/client/ClientServiceIT.java
+++ b/src/test/java/de/siegmar/billomat4j/client/ClientServiceIT.java
@@ -206,6 +206,8 @@ public class ClientServiceIT extends AbstractServiceIT {
         client.setSepaMandateDate(sepaDate);
         clientService.createClient(client);
         assertNotNull(client.getId());
+        assertEquals(client.getSepaMandate(), sepaMandateNr);
+        assertEquals(client.getSepaMandateDate(), sepaDate);
     }
 
 }


### PR DESCRIPTION
Hi Siegmar,

erst einmal vielen Dank für die Lib - hat mir viel Arbeit erspart :) 

Ich würde gerne beim Anlegen eines Kunden die SEPA Mandats Nr. und das entsprechende Datum hinzufügen. Ich habe diese beiden Werte entsprechend der Billomat-Schnittstelle hinzugefügt. Bei Test war ich mir nicht ganz sicher, wo das rein passt. Falls die Stelle falsch ist, bessere ich gerne nochmal nach.

Viele Grüße - Claus